### PR TITLE
Add support for sgx-runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c5fdd0166095e1d463fc6cc01aa8ce547ad77a4e84d42eb6762b084e28067e"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,9 +53,21 @@ dependencies = [
 name = "dot4gravity"
 version = "0.1.0"
 dependencies = [
+ "fixed-hash",
  "parity-scale-codec",
- "rand",
  "scale-info",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+dependencies = [
+ "byteorder",
+ "rand",
+ "rustc-hex",
+ "static_assertions",
 ]
 
 [[package]]
@@ -60,9 +78,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
@@ -183,6 +201,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
 name = "scale-info"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +236,12 @@ name = "serde"
 version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
@@ -267,9 +297,9 @@ checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wyz"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c5fdd0166095e1d463fc6cc01aa8ce547ad77a4e84d42eb6762b084e28067e"
 
 [[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,21 +47,8 @@ dependencies = [
 name = "dot4gravity"
 version = "0.1.0"
 dependencies = [
- "fixed-hash",
  "parity-scale-codec",
  "scale-info",
-]
-
-[[package]]
-name = "fixed-hash"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
-dependencies = [
- "byteorder",
- "rand",
- "rustc-hex",
- "static_assertions",
 ]
 
 [[package]]
@@ -75,17 +56,6 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
-name = "getrandom"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
 
 [[package]]
 name = "impl-trait-for-tuples"
@@ -97,12 +67,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "libc"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "parity-scale-codec"
@@ -129,12 +93,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro-crate"
@@ -171,42 +129,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "rustc-hex"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
-
-[[package]]
 name = "scale-info"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,12 +158,6 @@ name = "serde"
 version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
@@ -294,12 +210,6 @@ name = "unicode-ident"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wyz"

--- a/dot4gravity/Cargo.toml
+++ b/dot4gravity/Cargo.toml
@@ -6,15 +6,14 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand  = { version = "0.8.5", default-features = false, optional = true, features = [ "std_rng" ]}
-
 codec = { default-features = false, features = [ "derive", "max-encoded-len" ], package = "parity-scale-codec", version = "3.0.0" }
-scale-info = { default-features = false, features = [ "derive" ], version = "2.1" }
+scale-info = { default-features = false, features = [ "derive" ], version = "2.0.1" }
+fixed-hash = { default-features = false, features = [ "std" ], version = "0.7.0" }
 
 [features]
 default = [ "std" ]
 std = [
-    "rand/std",
     "codec/std",
     "scale-info/std",
+    "fixed-hash/std",
 ]

--- a/dot4gravity/Cargo.toml
+++ b/dot4gravity/Cargo.toml
@@ -8,12 +8,10 @@ edition = "2021"
 [dependencies]
 codec = { default-features = false, features = [ "derive", "max-encoded-len" ], package = "parity-scale-codec", version = "3.0.0" }
 scale-info = { default-features = false, features = [ "derive" ], version = "2.0.1" }
-fixed-hash = { default-features = false, features = [ "std" ], version = "0.7.0" }
 
 [features]
 default = [ "std" ]
 std = [
     "codec/std",
     "scale-info/std",
-    "fixed-hash/std",
 ]

--- a/dot4gravity/src/lib.rs
+++ b/dot4gravity/src/lib.rs
@@ -592,7 +592,7 @@ impl<Player: PartialEq + Clone> Game<Player> {
         Ok(game_state)
     }
 
-    pub fn check_winner_player(mut game_state: GameState<Player>) -> GameState<Player> {
+    fn check_winner_player(mut game_state: GameState<Player>) -> GameState<Player> {
         if game_state.winner.is_some() {
             return game_state;
         }

--- a/dot4gravity/src/tests.rs
+++ b/dot4gravity/src/tests.rs
@@ -138,12 +138,10 @@ fn should_create_new_game() {
     assert_eq!(
         game_state.get_player_bombs(&ALICE),
         Some(NUM_OF_BOMBS_PER_PLAYER),
-        "Alice should have {NUM_OF_BOMBS_PER_PLAYER} bombs"
     );
     assert_eq!(
         game_state.get_player_bombs(&BOB),
         Some(NUM_OF_BOMBS_PER_PLAYER),
-        "Bob should have {NUM_OF_BOMBS_PER_PLAYER} bombs"
     );
     assert!(
         game_state.is_player_in_game(&ALICE),

--- a/dot4gravity/src/tests.rs
+++ b/dot4gravity/src/tests.rs
@@ -16,16 +16,16 @@
 
 use crate::*;
 
-const ALICE: u32 = 0;
-const BOB: u32 = 1;
-const CHARLIE: u32 = 2;
+const ALICE: u8 = 11;
+const BOB: u8 = 22;
+const CHARLIE: u8 = 33;
 const TEST_COORDINATES: Coordinates = Coordinates::new(0, 0);
 
 struct MockRandomBoard;
 
 impl BlocksGenerator for MockRandomBoard {
     fn add_blocks(_: Board, _: usize) -> Board {
-        let board_blocks: Vec<(u8, u8)> = vec![
+        let board_blocks = [
             (0, 9),
             (1, 1),
             (1, 3),
@@ -133,7 +133,7 @@ fn should_create_new_game() {
         "The game should start in bomb phase"
     );
     assert_eq!(game_state.winner, None, "No player should have won yet");
-    assert_eq!(game_state.next_player, ALICE);
+    assert_eq!(game_state.next_player, game_state.player_index(&ALICE));
     assert_eq!(game_state.bombs.len(), NUM_OF_PLAYERS);
     assert_eq!(
         game_state.get_player_bombs(&ALICE),
@@ -214,13 +214,17 @@ fn a_player_drops_a_bomb() {
     );
     assert_eq!(
         game_state.board.get_cell(&TEST_COORDINATES),
-        Cell::Bomb([Some(ALICE), None])
+        Cell::Bomb([Some(game_state.player_index(&ALICE)), None])
     )
 }
 
 #[test]
 fn a_cell_can_hold_one_or_more_bombs_from_different_players() {
     let mut game_state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let (alice_index, bob_index) = (
+        game_state.player_index(&ALICE),
+        game_state.player_index(&BOB),
+    );
 
     let drop_bomb_result = Game::drop_bomb(game_state, TEST_COORDINATES, ALICE);
     assert!(drop_bomb_result.is_ok());
@@ -228,7 +232,7 @@ fn a_cell_can_hold_one_or_more_bombs_from_different_players() {
 
     assert_eq!(
         game_state.board.get_cell(&TEST_COORDINATES),
-        Cell::Bomb([Some(ALICE), None])
+        Cell::Bomb([Some(alice_index), None])
     );
 
     let drop_bomb_result = Game::drop_bomb(game_state, TEST_COORDINATES.clone(), BOB);
@@ -237,14 +241,18 @@ fn a_cell_can_hold_one_or_more_bombs_from_different_players() {
 
     assert_eq!(
         game_state.board.get_cell(&TEST_COORDINATES),
-        Cell::Bomb([Some(ALICE), Some(BOB)])
+        Cell::Bomb([Some(alice_index), Some(bob_index)])
     );
 }
 
 #[test]
 fn a_cell_cannot_hold_more_than_allowed_number_of_bombs() {
     let mut game_state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
-    let bombed_cell = Cell::Bomb([Some(BOB), Some(ALICE)]);
+    let (alice_index, bob_index) = (
+        game_state.player_index(&ALICE),
+        game_state.player_index(&BOB),
+    );
+    let bombed_cell = Cell::Bomb([Some(bob_index), Some(alice_index)]);
     game_state.board.update_cell(TEST_COORDINATES, bombed_cell);
     assert_eq!(
         Game::drop_bomb(game_state, TEST_COORDINATES.clone(), ALICE),
@@ -273,6 +281,7 @@ fn a_bomb_cannot_be_placed_in_a_cell_occupied_by_a_block() {
 #[test]
 fn a_player_cannot_place_more_than_one_bomb_in_a_cell() {
     let mut game_state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let alice_index = game_state.player_index(&ALICE);
 
     // Drop the first bomb
     let drop_bomb_result = Game::drop_bomb(game_state, TEST_COORDINATES, ALICE);
@@ -284,7 +293,7 @@ fn a_player_cannot_place_more_than_one_bomb_in_a_cell() {
 
     assert_eq!(
         game_state.board.get_cell(&TEST_COORDINATES),
-        Cell::Bomb([Some(ALICE), None])
+        Cell::Bomb([Some(alice_index), None])
     );
 
     // Drop the second bomb
@@ -345,19 +354,20 @@ fn a_stone_dropped_from_north_side_should_move_until_it_reaches_an_obstacle() {
     state.board.cells = cells;
 
     let state = Game::drop_stone(state, ALICE, Side::North, 0).unwrap();
+    let (alice_index, bob_index) = (state.player_index(&ALICE), state.player_index(&BOB));
     assert_eq!(
         state.board.get_cell(&Coordinates { row: 9, col: 0 }),
-        Cell::Stone(ALICE)
+        Cell::Stone(alice_index)
     );
     let state = Game::drop_stone(state, BOB, Side::North, 1).unwrap();
     assert_eq!(
         state.board.get_cell(&Coordinates { row: 8, col: 1 }),
-        Cell::Stone(BOB)
+        Cell::Stone(bob_index)
     );
     let state = Game::drop_stone(state, ALICE, Side::North, 2).unwrap();
     assert_eq!(
         state.board.get_cell(&Coordinates { row: 0, col: 2 }),
-        Cell::Stone(ALICE)
+        Cell::Stone(alice_index)
     );
     assert_eq!(
         Game::drop_stone(state, BOB, Side::North, 3).unwrap_err(),
@@ -384,22 +394,23 @@ fn a_stone_dropped_from_south_side_should_move_until_it_reaches_an_obstacle() {
     ];
 
     let mut state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let (alice_index, bob_index) = (state.player_index(&ALICE), state.player_index(&BOB));
     state.board.cells = cells;
 
     let state = Game::drop_stone(state, ALICE, Side::South, 0).unwrap();
     assert_eq!(
         state.board.get_cell(&Coordinates { row: 0, col: 0 }),
-        Cell::Stone(ALICE)
+        Cell::Stone(alice_index)
     );
     let state = Game::drop_stone(state, BOB, Side::South, 1).unwrap();
     assert_eq!(
         state.board.get_cell(&Coordinates { row: 1, col: 1 }),
-        Cell::Stone(BOB)
+        Cell::Stone(bob_index)
     );
     let state = Game::drop_stone(state, ALICE, Side::South, 2).unwrap();
     assert_eq!(
         state.board.get_cell(&Coordinates { row: 9, col: 2 }),
-        Cell::Stone(ALICE)
+        Cell::Stone(alice_index)
     );
     assert_eq!(
         Game::drop_stone(state, BOB, Side::South, 3).unwrap_err(),
@@ -426,22 +437,23 @@ fn a_stone_dropped_from_east_side_should_move_until_it_reaches_an_obstacle() {
     ];
 
     let mut state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let (alice_index, bob_index) = (state.player_index(&ALICE), state.player_index(&BOB));
     state.board.cells = cells;
 
     let state = Game::drop_stone(state, ALICE, Side::East, 0).unwrap();
     assert_eq!(
         state.board.get_cell(&Coordinates { row: 0, col: 0 }),
-        Cell::Stone(ALICE)
+        Cell::Stone(alice_index)
     );
     let state = Game::drop_stone(state, BOB, Side::East, 1).unwrap();
     assert_eq!(
         state.board.get_cell(&Coordinates { row: 1, col: 1 }),
-        Cell::Stone(BOB)
+        Cell::Stone(bob_index)
     );
     let state = Game::drop_stone(state, ALICE, Side::East, 2).unwrap();
     assert_eq!(
         state.board.get_cell(&Coordinates { row: 2, col: 9 }),
-        Cell::Stone(ALICE)
+        Cell::Stone(alice_index)
     );
     assert_eq!(
         Game::drop_stone(state, BOB, Side::East, 3).unwrap_err(),
@@ -471,19 +483,20 @@ fn a_stone_dropped_from_west_side_should_move_until_it_reaches_an_obstacle() {
     state.board.cells = cells;
 
     let state = Game::drop_stone(state, ALICE, Side::West, 0).unwrap();
+    let (alice_index, bob_index) = (state.player_index(&ALICE), state.player_index(&BOB));
     assert_eq!(
         state.board.get_cell(&Coordinates { row: 0, col: 9 }),
-        Cell::Stone(ALICE)
+        Cell::Stone(alice_index)
     );
     let state = Game::drop_stone(state, BOB, Side::West, 1).unwrap();
     assert_eq!(
         state.board.get_cell(&Coordinates { row: 1, col: 8 }),
-        Cell::Stone(BOB)
+        Cell::Stone(bob_index)
     );
     let state = Game::drop_stone(state, ALICE, Side::West, 2).unwrap();
     assert_eq!(
         state.board.get_cell(&Coordinates { row: 2, col: 0 }),
-        Cell::Stone(ALICE)
+        Cell::Stone(alice_index)
     );
     assert_eq!(
         Game::drop_stone(state, BOB, Side::West, 3).unwrap_err(),
@@ -493,12 +506,12 @@ fn a_stone_dropped_from_west_side_should_move_until_it_reaches_an_obstacle() {
 
 #[test]
 fn a_stone_should_explode_a_bomb_when_passing_through() {
-    let o = Cell::Empty;
-    let b = Cell::Bomb([Some(ALICE), Some(BOB)]);
-    let x = Cell::Stone(ALICE);
-    let l = Cell::Block;
-
     let mut state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let (alice_index, bob_index) = (state.player_index(&ALICE), state.player_index(&BOB));
+    let o = Cell::Empty;
+    let b = Cell::Bomb([Some(alice_index), Some(bob_index)]);
+    let x = Cell::Stone(alice_index);
+    let l = Cell::Block;
     state.board.cells = [
         [o, o, o, o, o, o, o, o, b, o],
         [o, o, o, o, o, o, o, o, o, o],
@@ -537,7 +550,7 @@ fn a_stone_should_explode_a_bomb_when_passing_through() {
     // Bomb in position 2,3 should not be destroyed.
     assert_eq!(
         state.board.get_cell(&Coordinates { row: 2, col: 3 }),
-        Cell::Bomb([Some(ALICE), Some(BOB)])
+        Cell::Bomb([Some(alice_index), Some(bob_index)])
     );
 
     let dropping_stone_result = Game::drop_stone(state.clone(), BOB, Side::North, 8);
@@ -575,10 +588,10 @@ fn a_stone_should_explode_a_bomb_when_passing_through() {
 
 #[test]
 fn a_player_wins_when_has_a_four_stone_vertical_row() {
-    let o = Cell::Empty;
-    let s = Cell::Stone(ALICE);
-
     let mut state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let alice_index = state.player_index(&ALICE);
+    let o = Cell::Empty;
+    let s = Cell::Stone(alice_index);
     state.board.cells = [
         [o, o, o, o, o, o, o, o, o, o],
         [o, o, o, o, o, o, o, o, o, o],
@@ -593,15 +606,15 @@ fn a_player_wins_when_has_a_four_stone_vertical_row() {
     ];
 
     state = Game::check_winner_player(state);
-    assert_eq!(state.winner, Some(ALICE));
+    assert_eq!(state.winner, Some(alice_index));
 }
 
 #[test]
 fn a_player_wins_when_has_a_four_stone_horizontal_row() {
-    let o = Cell::Empty;
-    let s = Cell::Stone(ALICE);
-
     let mut state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let alice_index = state.player_index(&ALICE);
+    let o = Cell::Empty;
+    let s = Cell::Stone(alice_index);
     state.board.cells = [
         [o, o, o, o, o, o, o, o, o, o],
         [o, o, o, o, o, o, o, o, o, o],
@@ -616,15 +629,15 @@ fn a_player_wins_when_has_a_four_stone_horizontal_row() {
     ];
 
     state = Game::check_winner_player(state);
-    assert_eq!(state.winner, Some(ALICE));
+    assert_eq!(state.winner, Some(alice_index));
 }
 
 #[test]
 fn a_player_wins_when_has_a_four_stone_ascending_diagonal_row() {
-    let o = Cell::Empty;
-    let s = Cell::Stone(ALICE);
-
     let mut state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let alice_index = state.player_index(&ALICE);
+    let o = Cell::Empty;
+    let s = Cell::Stone(alice_index);
     state.board.cells = [
         [o, o, o, o, o, o, o, o, o, o],
         [o, o, o, o, o, o, o, o, o, o],
@@ -639,15 +652,15 @@ fn a_player_wins_when_has_a_four_stone_ascending_diagonal_row() {
     ];
 
     state = Game::check_winner_player(state);
-    assert_eq!(state.winner, Some(ALICE));
+    assert_eq!(state.winner, Some(alice_index));
 }
 
 #[test]
 fn a_player_wins_when_has_a_four_stone_descending_diagonal_row() {
-    let o = Cell::Empty;
-    let s = Cell::Stone(ALICE);
-
     let mut state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let alice_index = state.player_index(&ALICE);
+    let o = Cell::Empty;
+    let s = Cell::Stone(alice_index);
     state.board.cells = [
         [o, o, o, o, o, o, o, o, o, o],
         [o, o, o, o, o, o, o, o, o, o],
@@ -662,17 +675,16 @@ fn a_player_wins_when_has_a_four_stone_descending_diagonal_row() {
     ];
 
     state = Game::check_winner_player(state);
-    assert_eq!(state.winner, Some(ALICE));
+    assert_eq!(state.winner, Some(alice_index));
 }
 
 #[test]
 fn no_player_wins_for_less_than_four_in_a_row_stones() {
+    let mut state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
     let o = Cell::Empty;
     let b = Cell::Block;
-    let r = Cell::Stone(ALICE);
-    let m = Cell::Stone(BOB);
-
-    let mut state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let r = Cell::Stone(state.player_index(&ALICE));
+    let m = Cell::Stone(state.player_index(&BOB));
     state.board.cells = [
         [o, r, o, o, o, o, o, o, m, o],
         [m, o, o, o, o, o, o, o, o, o],
@@ -817,7 +829,7 @@ fn should_play_a_game() {
     state = Game::drop_stone(state.clone(), ALICE, Side::South, 8).unwrap();
 
     assert!(state.winner.is_some());
-    assert_eq!(state.winner.unwrap(), ALICE);
+    assert_eq!(state.winner.unwrap(), state.player_index(&ALICE));
 }
 
 #[cfg(test)]

--- a/dot4gravity/src/tests.rs
+++ b/dot4gravity/src/tests.rs
@@ -21,36 +21,6 @@ const BOB: u8 = 22;
 const CHARLIE: u8 = 33;
 const TEST_COORDINATES: Coordinates = Coordinates::new(0, 0);
 
-struct MockRandomBoard;
-
-impl BlocksGenerator for MockRandomBoard {
-    fn add_blocks(_: Board, _: usize) -> Board {
-        let board_blocks = [
-            (0, 9),
-            (1, 1),
-            (1, 3),
-            (2, 2),
-            (2, 6),
-            (6, 1),
-            (6, 6),
-            (7, 4),
-            (8, 3),
-            (8, 9),
-        ];
-        let mut board = Board::new();
-        board_blocks.iter().for_each(|(row, col)| {
-            board.update_cell(
-                Coordinates {
-                    row: *row,
-                    col: *col,
-                },
-                Cell::Block,
-            )
-        });
-        board
-    }
-}
-
 #[test]
 fn should_create_a_new_board() {
     fn is_empty(board: &Board) -> bool {
@@ -90,43 +60,8 @@ fn board_cell_can_be_changed() {
 }
 
 #[test]
-fn mock_blocks_generator_generates_the_expected_board() {
-    let game = Game::new_game::<MockRandomBoard>(ALICE, BOB);
-    let o = Cell::Empty;
-    let x = Cell::Block;
-    assert_eq!(
-        game.board,
-        Board {
-            cells: [
-                [o, o, o, o, o, o, o, o, o, x],
-                [o, x, o, x, o, o, o, o, o, o],
-                [o, o, x, o, o, o, x, o, o, o],
-                [o, o, o, o, o, o, o, o, o, o],
-                [o, o, o, o, o, o, o, o, o, o],
-                [o, o, o, o, o, o, o, o, o, o],
-                [o, x, o, o, o, o, x, o, o, o],
-                [o, o, o, o, x, o, o, o, o, o],
-                [o, o, o, x, o, o, o, o, o, x],
-                [o, o, o, o, o, o, o, o, o, o]
-            ]
-        }
-    );
-}
-
-#[test]
-fn random_generator() {
-    let state = Game::new_game::<RandomBlocksGenerator>(ALICE, BOB);
-    let mock_state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
-    for _ in 0..100 {
-        let loop_state = Game::new_game::<RandomBlocksGenerator>(ALICE, BOB);
-        assert_ne!(state.board, loop_state.board);
-        assert_ne!(mock_state.board, loop_state.board);
-    }
-}
-
-#[test]
 fn should_create_new_game() {
-    let game_state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let game_state = Game::new_game(ALICE, BOB);
     assert_eq!(
         game_state.phase,
         GamePhase::Bomb,
@@ -154,34 +89,40 @@ fn should_create_new_game() {
 }
 
 #[test]
-fn a_board_in_a_new_game_should_contain_random_blocks() {
-    let state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
-    let mut blocks = 0;
+fn should_create_new_game_with_random_blocks() {
+    let blocks = |board: Board| -> u8 {
+        let mut block_count = 0;
+        board.cells.iter().for_each(|row| {
+            row.iter().for_each(|cell| {
+                if let Cell::Block = cell {
+                    block_count += 1;
+                }
+            })
+        });
+        block_count
+    };
 
-    // Count all cells of type 'block' in board.
-    for i in 0..BOARD_HEIGHT {
-        for j in 0..BOARD_WIDTH {
-            if state.board.get_cell(&Coordinates { row: i, col: j }) == Cell::Block {
-                blocks += 1;
-            }
-        }
+    for _ in 0..20 {
+        let game_1 = Game::new_game(ALICE, BOB);
+        let game_2 = Game::new_game(ALICE, BOB);
+        assert_ne!(game_1.board, game_2.board);
+        assert_eq!(blocks(game_1.board), NUM_OF_BLOCKS);
+        assert_eq!(blocks(game_2.board), NUM_OF_BLOCKS);
     }
-
-    assert_eq!(blocks, NUM_OF_BLOCKS);
 }
 
 #[test]
 fn a_player_cannot_drop_bomb_in_play_phase() {
-    let mut game_state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let mut game_state = Game::new_game(ALICE, BOB);
     game_state.phase = GamePhase::Play;
-    let result = Game::drop_bomb(game_state, Coordinates { row: 0, col: 0 }, ALICE);
+    let result = Game::drop_bomb(game_state, TEST_COORDINATES, ALICE);
     assert_eq!(result, Err(GameError::DroppedBombDuringPlayPhase));
 }
 
 #[test]
 fn a_player_cannot_drop_bomb_if_already_dropped_all() {
     for n in 0..NUM_OF_BOMBS_PER_PLAYER {
-        let mut game_state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+        let mut game_state = Game::new_game(ALICE, BOB);
         game_state.bombs = [(ALICE, 0), (BOB, n)];
         assert_eq!(
             Game::drop_bomb(game_state, TEST_COORDINATES, ALICE),
@@ -198,15 +139,13 @@ fn a_player_cannot_drop_bomb_if_already_dropped_all() {
 
 #[test]
 fn a_player_drops_a_bomb() {
-    let game_state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let mut game_state = Game::new_game(ALICE, BOB);
+    game_state.board.update_cell(TEST_COORDINATES, Cell::Empty);
 
     let player_bombs = game_state.get_player_bombs(&ALICE).unwrap();
     assert_eq!(player_bombs, NUM_OF_BOMBS_PER_PLAYER);
 
-    let drop_bomb_result = Game::drop_bomb(game_state, TEST_COORDINATES, ALICE);
-    assert!(drop_bomb_result.is_ok());
-    let game_state = drop_bomb_result.unwrap();
-
+    let game_state = Game::drop_bomb(game_state, TEST_COORDINATES, ALICE).unwrap();
     assert_eq!(
         game_state.get_player_bombs(&ALICE).unwrap(),
         player_bombs - 1,
@@ -220,11 +159,12 @@ fn a_player_drops_a_bomb() {
 
 #[test]
 fn a_cell_can_hold_one_or_more_bombs_from_different_players() {
-    let mut game_state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let mut game_state = Game::new_game(ALICE, BOB);
     let (alice_index, bob_index) = (
         game_state.player_index(&ALICE),
         game_state.player_index(&BOB),
     );
+    game_state.board.update_cell(TEST_COORDINATES, Cell::Empty);
 
     let drop_bomb_result = Game::drop_bomb(game_state, TEST_COORDINATES, ALICE);
     assert!(drop_bomb_result.is_ok());
@@ -247,7 +187,7 @@ fn a_cell_can_hold_one_or_more_bombs_from_different_players() {
 
 #[test]
 fn a_cell_cannot_hold_more_than_allowed_number_of_bombs() {
-    let mut game_state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let mut game_state = Game::new_game(ALICE, BOB);
     let (alice_index, bob_index) = (
         game_state.player_index(&ALICE),
         game_state.player_index(&BOB),
@@ -266,7 +206,7 @@ fn a_cell_cannot_hold_more_than_allowed_number_of_bombs() {
 
 #[test]
 fn a_bomb_cannot_be_placed_in_a_cell_occupied_by_a_block() {
-    let mut game_state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let mut game_state = Game::new_game(ALICE, BOB);
     game_state.board.update_cell(TEST_COORDINATES, Cell::Block);
     assert_eq!(
         Game::drop_bomb(game_state, TEST_COORDINATES, ALICE),
@@ -280,8 +220,9 @@ fn a_bomb_cannot_be_placed_in_a_cell_occupied_by_a_block() {
 
 #[test]
 fn a_player_cannot_place_more_than_one_bomb_in_a_cell() {
-    let mut game_state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let mut game_state = Game::new_game(ALICE, BOB);
     let alice_index = game_state.player_index(&ALICE);
+    game_state.board.update_cell(TEST_COORDINATES, Cell::Empty);
 
     // Drop the first bomb
     let drop_bomb_result = Game::drop_bomb(game_state, TEST_COORDINATES, ALICE);
@@ -303,7 +244,7 @@ fn a_player_cannot_place_more_than_one_bomb_in_a_cell() {
 
 #[test]
 fn a_game_can_change_game_phase() {
-    let game_state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let game_state = Game::new_game(ALICE, BOB);
     assert_eq!(game_state.phase, GamePhase::Bomb);
     let game_state = Game::change_game_phase(game_state, GamePhase::Play);
     assert_eq!(game_state.phase, GamePhase::Play);
@@ -313,14 +254,17 @@ fn a_game_can_change_game_phase() {
 
 #[test]
 fn a_player_cannot_drop_a_stone_out_of_turn() {
-    let state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let state = Game::new_game(ALICE, BOB);
     let drop_stone_result = Game::drop_stone(state, BOB, Side::North, 0);
     assert_eq!(drop_stone_result, Err(GameError::NotPlayerTurn));
 }
 
 #[test]
 fn player_turn_changes_after_dropping_stone() {
-    let mut state = Game::new_game::<MockRandomBoard>(CHARLIE, BOB);
+    let mut state = Game::new_game(CHARLIE, BOB);
+    for i in 0..BOARD_WIDTH {
+        state.board.update_cell(Coordinates::new(i, 0), Cell::Empty);
+    }
     state.phase = GamePhase::Play;
     let drop_stone_result = Game::drop_stone(state, CHARLIE, Side::North, 0);
     assert!(drop_stone_result.is_ok());
@@ -350,7 +294,7 @@ fn a_stone_dropped_from_north_side_should_move_until_it_reaches_an_obstacle() {
         [o, b, o, o, o, o, o, o, o, o],
     ];
 
-    let mut state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let mut state = Game::new_game(ALICE, BOB);
     state.board.cells = cells;
 
     let state = Game::drop_stone(state, ALICE, Side::North, 0).unwrap();
@@ -393,7 +337,7 @@ fn a_stone_dropped_from_south_side_should_move_until_it_reaches_an_obstacle() {
         [o, o, o, b, o, o, o, o, o, o],
     ];
 
-    let mut state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let mut state = Game::new_game(ALICE, BOB);
     let (alice_index, bob_index) = (state.player_index(&ALICE), state.player_index(&BOB));
     state.board.cells = cells;
 
@@ -436,7 +380,7 @@ fn a_stone_dropped_from_east_side_should_move_until_it_reaches_an_obstacle() {
         [o, o, o, o, o, o, o, o, o, o],
     ];
 
-    let mut state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let mut state = Game::new_game(ALICE, BOB);
     let (alice_index, bob_index) = (state.player_index(&ALICE), state.player_index(&BOB));
     state.board.cells = cells;
 
@@ -479,7 +423,7 @@ fn a_stone_dropped_from_west_side_should_move_until_it_reaches_an_obstacle() {
         [o, o, o, o, o, o, o, o, o, o],
     ];
 
-    let mut state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let mut state = Game::new_game(ALICE, BOB);
     state.board.cells = cells;
 
     let state = Game::drop_stone(state, ALICE, Side::West, 0).unwrap();
@@ -506,7 +450,7 @@ fn a_stone_dropped_from_west_side_should_move_until_it_reaches_an_obstacle() {
 
 #[test]
 fn a_stone_should_explode_a_bomb_when_passing_through() {
-    let mut state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let mut state = Game::new_game(ALICE, BOB);
     let (alice_index, bob_index) = (state.player_index(&ALICE), state.player_index(&BOB));
     let o = Cell::Empty;
     let b = Cell::Bomb([Some(alice_index), Some(bob_index)]);
@@ -588,7 +532,7 @@ fn a_stone_should_explode_a_bomb_when_passing_through() {
 
 #[test]
 fn a_player_wins_when_has_a_four_stone_vertical_row() {
-    let mut state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let mut state = Game::new_game(ALICE, BOB);
     let alice_index = state.player_index(&ALICE);
     let o = Cell::Empty;
     let s = Cell::Stone(alice_index);
@@ -611,7 +555,7 @@ fn a_player_wins_when_has_a_four_stone_vertical_row() {
 
 #[test]
 fn a_player_wins_when_has_a_four_stone_horizontal_row() {
-    let mut state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let mut state = Game::new_game(ALICE, BOB);
     let alice_index = state.player_index(&ALICE);
     let o = Cell::Empty;
     let s = Cell::Stone(alice_index);
@@ -634,7 +578,7 @@ fn a_player_wins_when_has_a_four_stone_horizontal_row() {
 
 #[test]
 fn a_player_wins_when_has_a_four_stone_ascending_diagonal_row() {
-    let mut state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let mut state = Game::new_game(ALICE, BOB);
     let alice_index = state.player_index(&ALICE);
     let o = Cell::Empty;
     let s = Cell::Stone(alice_index);
@@ -657,7 +601,7 @@ fn a_player_wins_when_has_a_four_stone_ascending_diagonal_row() {
 
 #[test]
 fn a_player_wins_when_has_a_four_stone_descending_diagonal_row() {
-    let mut state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let mut state = Game::new_game(ALICE, BOB);
     let alice_index = state.player_index(&ALICE);
     let o = Cell::Empty;
     let s = Cell::Stone(alice_index);
@@ -680,7 +624,7 @@ fn a_player_wins_when_has_a_four_stone_descending_diagonal_row() {
 
 #[test]
 fn no_player_wins_for_less_than_four_in_a_row_stones() {
-    let mut state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let mut state = Game::new_game(ALICE, BOB);
     let o = Cell::Empty;
     let b = Cell::Block;
     let r = Cell::Stone(state.player_index(&ALICE));
@@ -707,7 +651,7 @@ fn should_play_a_game() {
     let o = Cell::Empty;
     let b = Cell::Block;
 
-    let mut state = Game::new_game::<MockRandomBoard>(ALICE, BOB);
+    let mut state = Game::new_game(ALICE, BOB);
     state.board.cells = [
         [o, o, o, o, o, o, o, o, b, o],
         [b, o, o, o, o, o, o, o, o, o],
@@ -830,38 +774,4 @@ fn should_play_a_game() {
 
     assert!(state.winner.is_some());
     assert_eq!(state.winner.unwrap(), state.player_index(&ALICE));
-}
-
-#[cfg(test)]
-mod random_block_generator_tests {
-    use super::*;
-
-    fn block_count(board: Board) -> usize {
-        let mut count = 0;
-        board.cells.iter().for_each(|x| {
-            x.iter().for_each(|y| {
-                if *y == Cell::Block {
-                    count += 1;
-                }
-            })
-        });
-        count
-    }
-
-    #[test]
-    fn number_of_blocks_added_should_match_specified() {
-        for n in 0..(BOARD_WIDTH * BOARD_HEIGHT) as usize {
-            let board = RandomBlocksGenerator::add_blocks(Board::new(), n);
-            assert_eq!(block_count(board), n);
-        }
-    }
-
-    #[test]
-    fn blocks_should_be_added_in_random_positions() {
-        for n in 1..(BOARD_WIDTH * BOARD_HEIGHT) as usize {
-            let board_1 = RandomBlocksGenerator::add_blocks(Board::new(), n);
-            let board_2 = RandomBlocksGenerator::add_blocks(Board::new(), n);
-            assert_ne!(board_1, board_2);
-        }
-    }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel    = "nightly-2021-11-10"
+components = [ "clippy", "rustfmt" ]
+profile    = "minimal"
+targets    = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
Changes:
- https://github.com/ajuna-network/ajuna-games/pull/4/commits/e36606c56bafd909acea4dfacf7a6491eb99dab7: align toolchain with sgx-runtime
  - because all our games will integrate with sgx support
- https://github.com/ajuna-network/ajuna-games/pull/4/commits/c9f9b25536bd56b0daf7549a937a1d0c6177e08c: make player generic
  - allow `GameState` to take `Player` as generic type and update `impl` accordingly
  - change `Player` -> `PlayerIndex` type (to be more explicit)
  - add `player_index` getter
- https://github.com/ajuna-network/ajuna-games/pull/4/commits/be4154f9d96f0a8ce5a590cf97cc0f1e486514a5: make check_winner_player private
  - we will check `game_state.winner` directly from pallet
- https://github.com/ajuna-network/ajuna-games/pull/4/commits/5eff3fbafa49239646a18a0b0264c1753a1558fb: use linear congruential generator
  - using LCG instead of adding other dependencies, as suggested by Integritee