### PR TITLE
catch overflow on first row for stone on stone

### DIFF
--- a/dot4gravity/src/lib.rs
+++ b/dot4gravity/src/lib.rs
@@ -426,7 +426,7 @@ impl<Player: PartialEq + Clone> Game<Player> {
                         Cell::Block => {
                             if row > 0 {
                                 game_state.board.update_cell(
-                                    Coordinates::new(position.row - 1, position.col),
+                                    Coordinates::new(position.row.saturating_sub(1), position.col),
                                     Cell::Stone(player_index),
                                 );
                             } else {
@@ -438,7 +438,7 @@ impl<Player: PartialEq + Clone> Game<Player> {
                         Cell::Stone(_) => {
                             if row > 0 {
                                 game_state.board.update_cell(
-                                    Coordinates::new(position.row - 1, position.col),
+                                    Coordinates::new(position.row.saturating_sub(1), position.col),
                                     Cell::Stone(player_index),
                                 );
                             } else {
@@ -577,7 +577,7 @@ impl<Player: PartialEq + Clone> Game<Player> {
                         Cell::Block => {
                             if col > 0 {
                                 game_state.board.update_cell(
-                                    Coordinates::new(position.row, position.col - 1),
+                                    Coordinates::new(position.row, position.col.saturating_sub(1)),
                                     Cell::Stone(player_index),
                                 );
                             } else {
@@ -589,7 +589,7 @@ impl<Player: PartialEq + Clone> Game<Player> {
                         Cell::Stone(_) => {
                             if col < BOARD_WIDTH - 1 {
                                 game_state.board.update_cell(
-                                    Coordinates::new(position.row, position.col - 1),
+                                    Coordinates::new(position.row, position.col.saturating_sub(1)),
                                     Cell::Stone(player_index),
                                 );
                             } else {

--- a/dot4gravity/src/tests.rs
+++ b/dot4gravity/src/tests.rs
@@ -293,6 +293,35 @@ fn player_turn_changes_after_dropping_stone() {
 }
 
 #[test]
+fn a_stone_dropped_on_a_stone() {
+    let mut state = Game::new_game(ALICE, BOB, Some(INITIAL_SEED));
+    let (alice_index, bob_index) = (state.player_index(&ALICE), state.player_index(&BOB));
+
+    let o = Cell::Empty;
+    let x = Cell::Stone(bob_index);
+    let cells = [
+        [x, o, o, o, o, o, o, o, o, o],
+        [o, o, o, o, o, o, o, o, o, o],
+        [o, o, o, o, o, o, o, o, o, o],
+        [o, o, o, o, o, o, o, o, o, o],
+        [o, o, o, o, o, o, o, o, o, o],
+        [o, o, o, o, o, o, o, o, o, o],
+        [o, o, o, o, o, o, o, o, o, o],
+        [o, o, o, o, o, o, o, o, o, o],
+        [o, o, o, o, o, o, o, o, o, o],
+        [o, o, o, o, o, o, o, o, o, o],
+    ];
+
+    state.board.cells = cells;
+
+    let state = Game::drop_stone(state, ALICE, Side::West, 0).unwrap();
+    assert_eq!(
+        state.board.get_cell(&Coordinates { row: 0, col: 0 }),
+        Cell::Stone(alice_index)
+    );
+}
+
+#[test]
 fn a_stone_dropped_from_north_side_should_move_until_it_reaches_an_obstacle() {
     let o = Cell::Empty;
     let b = Cell::Block;


### PR DESCRIPTION
Using `saturating_sub` to catch an overflow when we are dealing with stones in row 0