### PR TITLE
[Issue 7] remove concrete PlayerIndex type from GameState

### DIFF
--- a/dot4gravity/src/lib.rs
+++ b/dot4gravity/src/lib.rs
@@ -309,15 +309,13 @@ impl<Player: PartialEq + Clone> GameState<Player> {
         player_index
     }
 
-    fn next_player(&self) -> Player {
-        self.players
+    fn next_player(&self) -> &Player {
+        let current_player_index = self
+            .players
             .iter()
             .position(|player| *player == self.next_player)
-            .map(|current_player_index| {
-                let next_player_index = (current_player_index + 1) % NUM_OF_PLAYERS;
-                self.players[next_player_index].clone()
-            })
-            .expect("next_player to be a subset of players")
+            .expect("next player to be a subset of players");
+        &self.players[(current_player_index + 1) % NUM_OF_PLAYERS]
     }
 }
 
@@ -657,7 +655,7 @@ impl<Player: PartialEq + Clone> Game<Player> {
         }
 
         game_state.last_move = Some(LastMove::new(player, side, position));
-        game_state.next_player = game_state.next_player();
+        game_state.next_player = game_state.next_player().clone();
         game_state = Game::check_winner_player(game_state);
 
         Ok(game_state)

--- a/dot4gravity/src/lib.rs
+++ b/dot4gravity/src/lib.rs
@@ -255,9 +255,9 @@ pub struct GameState<Player> {
     /// Game mode.
     pub phase: GamePhase,
     /// When present,it contains the player that won.
-    pub winner: Option<PlayerIndex>,
+    pub winner: Option<Player>,
     /// Next player turn.
-    pub next_player: PlayerIndex,
+    pub next_player: Player,
     /// Players:
     pub players: [Player; NUM_OF_PLAYERS],
     /// Number of bombs available for each player.
@@ -266,7 +266,7 @@ pub struct GameState<Player> {
     pub last_move: Option<LastMove<Player>>,
 }
 
-impl<Player: PartialEq> GameState<Player> {
+impl<Player: PartialEq + Clone> GameState<Player> {
     fn is_all_bomb_dropped(&self) -> bool {
         self.bombs.iter().all(|(_, bombs)| *bombs == 0)
     }
@@ -298,7 +298,7 @@ impl<Player: PartialEq> GameState<Player> {
         }
     }
     pub fn is_player_turn(&self, player: &Player) -> bool {
-        self.players[self.next_player as usize] == *player
+        self.next_player == *player
     }
     fn player_index(&self, player: &Player) -> PlayerIndex {
         let player_index = self
@@ -308,12 +308,23 @@ impl<Player: PartialEq> GameState<Player> {
             .expect("game to always start with 2 players") as u8;
         player_index
     }
+
+    fn next_player(&self) -> Player {
+        self.players
+            .iter()
+            .position(|player| *player == self.next_player)
+            .map(|current_player_index| {
+                let next_player_index = (current_player_index + 1) % NUM_OF_PLAYERS;
+                self.players[next_player_index].clone()
+            })
+            .expect("next_player to be a subset of players")
+    }
 }
 
 #[derive(Encode, Decode, TypeInfo)]
 pub struct Game<Player>(PhantomData<Player>);
 
-impl<Player: PartialEq> Game<Player> {
+impl<Player: PartialEq + Clone> Game<Player> {
     fn can_drop_bomb(
         game_state: &GameState<Player>,
         position: &Coordinates,
@@ -377,7 +388,7 @@ impl<Player: PartialEq + Clone> Game<Player> {
             board,
             phase: Default::default(),
             winner: Default::default(),
-            next_player: Default::default(),
+            next_player: player1.clone(),
             players: [player1.clone(), player2.clone()],
             bombs: [
                 (player1, NUM_OF_BOMBS_PER_PLAYER),
@@ -646,7 +657,7 @@ impl<Player: PartialEq + Clone> Game<Player> {
         }
 
         game_state.last_move = Some(LastMove::new(player, side, position));
-        game_state.next_player = (game_state.next_player + 1) % NUM_OF_PLAYERS as u8;
+        game_state.next_player = game_state.next_player();
         game_state = Game::check_winner_player(game_state);
 
         Ok(game_state)
@@ -667,7 +678,8 @@ impl<Player: PartialEq + Clone> Game<Player> {
                         && cell == board.get_cell(&Coordinates::new(row + 2, col))
                         && cell == board.get_cell(&Coordinates::new(row + 3, col))
                     {
-                        game_state.winner = Some(player_index);
+                        let winner = game_state.players[player_index as usize].clone();
+                        game_state.winner = Some(winner);
                         break;
                     }
                 }
@@ -683,7 +695,8 @@ impl<Player: PartialEq + Clone> Game<Player> {
                         && cell == board.get_cell(&Coordinates::new(row, col + 2))
                         && cell == board.get_cell(&Coordinates::new(row, col + 3))
                     {
-                        game_state.winner = Some(player_index);
+                        let winner = game_state.players[player_index as usize].clone();
+                        game_state.winner = Some(winner);
                         break;
                     }
                 }
@@ -699,7 +712,8 @@ impl<Player: PartialEq + Clone> Game<Player> {
                         && cell == board.get_cell(&Coordinates::new(row - 2, col + 2))
                         && cell == board.get_cell(&Coordinates::new(row - 3, col + 3))
                     {
-                        game_state.winner = Some(player_index);
+                        let winner = game_state.players[player_index as usize].clone();
+                        game_state.winner = Some(winner);
                         break;
                     }
                 }
@@ -715,7 +729,8 @@ impl<Player: PartialEq + Clone> Game<Player> {
                         && cell == board.get_cell(&Coordinates::new(row + 2, col + 2))
                         && cell == board.get_cell(&Coordinates::new(row + 3, col + 3))
                     {
-                        game_state.winner = Some(player_index);
+                        let winner = game_state.players[player_index as usize].clone();
+                        game_state.winner = Some(winner);
                         break;
                     }
                 }

--- a/dot4gravity/src/tests.rs
+++ b/dot4gravity/src/tests.rs
@@ -70,7 +70,7 @@ fn should_create_new_game() {
         "The game should start in bomb phase"
     );
     assert_eq!(game_state.winner, None, "No player should have won yet");
-    assert_eq!(game_state.next_player, game_state.player_index(&ALICE));
+    assert_eq!(game_state.next_player, ALICE);
     assert_eq!(game_state.bombs.len(), NUM_OF_PLAYERS);
     assert_eq!(
         game_state.get_player_bombs(&ALICE),
@@ -707,7 +707,7 @@ fn a_player_wins_when_has_a_four_stone_vertical_row() {
     ];
 
     state = Game::check_winner_player(state);
-    assert_eq!(state.winner, Some(alice_index));
+    assert_eq!(state.winner, Some(ALICE));
 }
 
 #[test]
@@ -730,7 +730,7 @@ fn a_player_wins_when_has_a_four_stone_horizontal_row() {
     ];
 
     state = Game::check_winner_player(state);
-    assert_eq!(state.winner, Some(alice_index));
+    assert_eq!(state.winner, Some(ALICE));
 }
 
 #[test]
@@ -753,7 +753,7 @@ fn a_player_wins_when_has_a_four_stone_ascending_diagonal_row() {
     ];
 
     state = Game::check_winner_player(state);
-    assert_eq!(state.winner, Some(alice_index));
+    assert_eq!(state.winner, Some(ALICE));
 }
 
 #[test]
@@ -776,7 +776,7 @@ fn a_player_wins_when_has_a_four_stone_descending_diagonal_row() {
     ];
 
     state = Game::check_winner_player(state);
-    assert_eq!(state.winner, Some(alice_index));
+    assert_eq!(state.winner, Some(ALICE));
 }
 
 #[test]
@@ -930,5 +930,5 @@ fn should_play_a_game() {
     state = Game::drop_stone(state.clone(), ALICE, Side::South, 8).unwrap();
 
     assert!(state.winner.is_some());
-    assert_eq!(state.winner.unwrap(), state.player_index(&ALICE));
+    assert_eq!(state.winner.unwrap(), ALICE);
 }


### PR DESCRIPTION
Removing the concrete `PlayerIndex` type from `GameState`.

For more context, this was part of a workaround to avoid propagating the generic `Player` type all the way down from `GameState` -> `Cell` (see the `Bomb` and `Stone` variants below): https://github.com/ajuna-network/ajuna-games/blob/1850d8d6c16a47e6e6c9cd47e01c4edd1918123f/dot4gravity/src/lib.rs#L43-L48

Closes #7.