### PR TITLE
[Issue 6] add checks for dropping stone

### DIFF
--- a/dot4gravity/src/lib.rs
+++ b/dot4gravity/src/lib.rs
@@ -206,8 +206,8 @@ pub enum GameError {
     NoMoreBombsAvailable,
     /// Tried to drop a bomb in an invalid cell. The cell is already taken.
     InvalidBombPosition,
-    /// Tried to drop in an invalid position.
-    InvalidDroppingPosition,
+    /// Tried to drop a stone in an invalid cell. The cell is already taken.
+    InvalidStonePosition,
     /// Tried to drop a stone during other player's turn
     NotPlayerTurn,
     /// The cell has no previous position. It is an edge cell.
@@ -303,7 +303,7 @@ impl<Player: PartialEq> Game<Player> {
         player: &Player,
     ) -> Result<(), GameError> {
         if position >= BOARD_HEIGHT || position >= BOARD_WIDTH {
-            return Err(GameError::InvalidDroppingPosition);
+            return Err(GameError::InvalidStonePosition);
         }
         if !game_state.is_player_turn(player) {
             return Err(GameError::NotPlayerTurn);
@@ -430,7 +430,7 @@ impl<Player: PartialEq + Clone> Game<Player> {
                                     Cell::Stone(player_index),
                                 );
                             } else {
-                                return Err(GameError::InvalidDroppingPosition);
+                                return Err(GameError::InvalidStonePosition);
                             }
                             stop = true;
                         }
@@ -442,7 +442,7 @@ impl<Player: PartialEq + Clone> Game<Player> {
                                     Cell::Stone(player_index),
                                 );
                             } else {
-                                return Err(GameError::InvalidDroppingPosition);
+                                return Err(GameError::InvalidStonePosition);
                             }
                             stop = true;
                         }
@@ -478,7 +478,7 @@ impl<Player: PartialEq + Clone> Game<Player> {
                                     Cell::Stone(player_index),
                                 );
                             } else {
-                                return Err(GameError::InvalidDroppingPosition);
+                                return Err(GameError::InvalidStonePosition);
                             }
                             break;
                         }
@@ -490,7 +490,7 @@ impl<Player: PartialEq + Clone> Game<Player> {
                                     Cell::Stone(player_index),
                                 );
                             } else {
-                                return Err(GameError::InvalidDroppingPosition);
+                                return Err(GameError::InvalidStonePosition);
                             }
                             break;
                         }
@@ -529,7 +529,7 @@ impl<Player: PartialEq + Clone> Game<Player> {
                                     Cell::Stone(player_index),
                                 );
                             } else {
-                                return Err(GameError::InvalidDroppingPosition);
+                                return Err(GameError::InvalidStonePosition);
                             }
                             break;
                         }
@@ -541,7 +541,7 @@ impl<Player: PartialEq + Clone> Game<Player> {
                                     Cell::Stone(player_index),
                                 );
                             } else {
-                                return Err(GameError::InvalidDroppingPosition);
+                                return Err(GameError::InvalidStonePosition);
                             }
                             break;
                         }
@@ -581,7 +581,7 @@ impl<Player: PartialEq + Clone> Game<Player> {
                                     Cell::Stone(player_index),
                                 );
                             } else {
-                                return Err(GameError::InvalidDroppingPosition);
+                                return Err(GameError::InvalidStonePosition);
                             }
                             stop = true;
                         }
@@ -593,7 +593,7 @@ impl<Player: PartialEq + Clone> Game<Player> {
                                     Cell::Stone(player_index),
                                 );
                             } else {
-                                return Err(GameError::InvalidDroppingPosition);
+                                return Err(GameError::InvalidStonePosition);
                             }
                             stop = true;
                         }

--- a/dot4gravity/src/lib.rs
+++ b/dot4gravity/src/lib.rs
@@ -16,12 +16,14 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use crate::traits::Bound;
 use codec::{Decode, Encode, MaxEncodedLen};
 use core::marker::PhantomData;
 use scale_info::{prelude::vec::Vec, TypeInfo};
 
 #[cfg(test)]
 mod tests;
+mod traits;
 
 const INITIAL_SEED: Seed = 123_456;
 const INCREMENT: Seed = 74;
@@ -97,11 +99,6 @@ impl Coordinates {
             ),
             random_seed_2,
         )
-    }
-
-    /// Tells if a cell is inside the board.
-    fn is_inside_board(&self) -> bool {
-        self.row < BOARD_WIDTH && self.col < BOARD_HEIGHT
     }
 
     /// Tells if a cell is in the opposite of a side.

--- a/dot4gravity/src/lib.rs
+++ b/dot4gravity/src/lib.rs
@@ -217,10 +217,10 @@ impl Default for GamePhase {
 
 #[derive(Encode, Decode, TypeInfo, Debug, Eq, PartialEq)]
 pub enum GameError {
-    /// Tried to drop a bomb during play phase.
-    DroppedBombDuringPlayPhase,
-    /// Tried to drop a stone during bomb phase.
-    DroppedStoneDuringBombPhase,
+    /// Tried to drop a bomb outside bomb phase.
+    DroppedBombOutsideBombPhase,
+    /// Tried to drop a stone outside play phase.
+    DroppedStoneOutsidePlayPhase,
     /// The player has no more bombs to drop.
     NoMoreBombsAvailable,
     /// Tried to drop a bomb in an invalid cell. The cell is already taken.
@@ -305,7 +305,7 @@ impl<Player: PartialEq> Game<Player> {
         player: &Player,
     ) -> Result<(), GameError> {
         if game_state.phase != GamePhase::Bomb {
-            return Err(GameError::DroppedBombDuringPlayPhase);
+            return Err(GameError::DroppedBombOutsideBombPhase);
         }
         if game_state.is_all_player_bomb_dropped(player) {
             return Err(GameError::NoMoreBombsAvailable);
@@ -323,7 +323,7 @@ impl<Player: PartialEq> Game<Player> {
         player: &Player,
     ) -> Result<(), GameError> {
         if game_state.phase != GamePhase::Play {
-            return Err(GameError::DroppedStoneDuringBombPhase);
+            return Err(GameError::DroppedStoneOutsidePlayPhase);
         }
         if !game_state.is_player_turn(player) {
             return Err(GameError::NotPlayerTurn);

--- a/dot4gravity/src/lib.rs
+++ b/dot4gravity/src/lib.rs
@@ -217,8 +217,10 @@ impl Default for GamePhase {
 
 #[derive(Encode, Decode, TypeInfo, Debug, Eq, PartialEq)]
 pub enum GameError {
-    /// Tried to drop a bomb during game play phase.
+    /// Tried to drop a bomb during play phase.
     DroppedBombDuringPlayPhase,
+    /// Tried to drop a stone during bomb phase.
+    DroppedStoneDuringBombPhase,
     /// The player has no more bombs to drop.
     NoMoreBombsAvailable,
     /// Tried to drop a bomb in an invalid cell. The cell is already taken.
@@ -302,7 +304,7 @@ impl<Player: PartialEq> Game<Player> {
         position: &Coordinates,
         player: &Player,
     ) -> Result<(), GameError> {
-        if game_state.phase == GamePhase::Play {
+        if game_state.phase != GamePhase::Bomb {
             return Err(GameError::DroppedBombDuringPlayPhase);
         }
         if game_state.is_all_player_bomb_dropped(player) {
@@ -320,6 +322,9 @@ impl<Player: PartialEq> Game<Player> {
         position: Position,
         player: &Player,
     ) -> Result<(), GameError> {
+        if game_state.phase != GamePhase::Play {
+            return Err(GameError::DroppedStoneDuringBombPhase);
+        }
         if !game_state.is_player_turn(player) {
             return Err(GameError::NotPlayerTurn);
         }

--- a/dot4gravity/src/lib.rs
+++ b/dot4gravity/src/lib.rs
@@ -59,12 +59,7 @@ impl Default for Cell {
 impl Cell {
     /// Tells if a cell is suitable for dropping a bomb.
     fn is_bomb_droppable(&self) -> bool {
-        *self == Cell::Empty || self.is_bomb()
-    }
-
-    /// Tells if a cell is of type 'bomb'
-    fn is_bomb(&self) -> bool {
-        matches!(self, Cell::Bomb(_))
+        matches!(self, Cell::Empty | Cell::Bomb(_))
     }
 
     /// Tells if a cell must be cleared when it's affected by an explosion.
@@ -72,6 +67,7 @@ impl Cell {
         *self != Cell::Block
     }
 
+    /// Tells if a cell is suitable for dropping a stone.
     fn is_stone_droppable(&self) -> bool {
         !matches!(self, Cell::Block | Cell::Stone(_))
     }

--- a/dot4gravity/src/tests.rs
+++ b/dot4gravity/src/tests.rs
@@ -359,7 +359,7 @@ fn a_stone_dropped_from_north_side_should_move_until_it_reaches_an_obstacle() {
     );
     assert_eq!(
         Game::drop_stone(state, BOB, Side::North, 3).unwrap_err(),
-        GameError::InvalidDroppingPosition
+        GameError::InvalidStonePosition
     );
 }
 
@@ -402,7 +402,7 @@ fn a_stone_dropped_from_south_side_should_move_until_it_reaches_an_obstacle() {
     );
     assert_eq!(
         Game::drop_stone(state, BOB, Side::South, 3).unwrap_err(),
-        GameError::InvalidDroppingPosition
+        GameError::InvalidStonePosition
     );
 }
 
@@ -445,7 +445,7 @@ fn a_stone_dropped_from_east_side_should_move_until_it_reaches_an_obstacle() {
     );
     assert_eq!(
         Game::drop_stone(state, BOB, Side::East, 3).unwrap_err(),
-        GameError::InvalidDroppingPosition
+        GameError::InvalidStonePosition
     );
 }
 
@@ -488,7 +488,7 @@ fn a_stone_dropped_from_west_side_should_move_until_it_reaches_an_obstacle() {
     );
     assert_eq!(
         Game::drop_stone(state, BOB, Side::West, 3).unwrap_err(),
-        GameError::InvalidDroppingPosition
+        GameError::InvalidStonePosition
     );
 }
 

--- a/dot4gravity/src/tests.rs
+++ b/dot4gravity/src/tests.rs
@@ -268,8 +268,19 @@ fn a_game_can_change_game_phase() {
 }
 
 #[test]
-fn a_player_cannot_drop_a_stone_out_of_turn() {
+fn a_player_cannot_drop_a_stone_in_bomb_phase() {
     let state = Game::new_game(ALICE, BOB, Some(INITIAL_SEED));
+    assert_eq!(state.phase, GamePhase::Bomb);
+    assert_eq!(
+        Game::drop_stone(state, BOB, Side::North, 0),
+        Err(GameError::DroppedStoneDuringBombPhase)
+    );
+}
+
+#[test]
+fn a_player_cannot_drop_a_stone_out_of_turn() {
+    let mut state = Game::new_game(ALICE, BOB, Some(INITIAL_SEED));
+    state.phase = GamePhase::Play;
     let drop_stone_result = Game::drop_stone(state, BOB, Side::North, 0);
     assert_eq!(drop_stone_result, Err(GameError::NotPlayerTurn));
 }
@@ -313,6 +324,7 @@ fn a_stone_dropped_on_a_stone() {
     ];
 
     state.board.cells = cells;
+    state.phase = GamePhase::Play;
 
     let state = Game::drop_stone(state, ALICE, Side::West, 0).unwrap();
     assert_eq!(
@@ -327,7 +339,8 @@ fn a_stone_dropped_on_a_stone() {
 
 #[test]
 fn a_stone_cannot_be_dropped_at_bounds() {
-    let state = Game::new_game(ALICE, BOB, Some(INITIAL_SEED));
+    let mut state = Game::new_game(ALICE, BOB, Some(INITIAL_SEED));
+    state.phase = GamePhase::Play;
 
     let mut state_with_stones_at_bounds = state;
     let o = Cell::Empty;
@@ -406,6 +419,7 @@ fn a_stone_dropped_from_north_side_should_move_until_it_reaches_an_obstacle() {
 
     let mut state = Game::new_game(ALICE, BOB, Some(INITIAL_SEED));
     state.board.cells = cells;
+    state.phase = GamePhase::Play;
 
     let state = Game::drop_stone(state, ALICE, Side::North, 0).unwrap();
     let (alice_index, bob_index) = (state.player_index(&ALICE), state.player_index(&BOB));
@@ -450,6 +464,7 @@ fn a_stone_dropped_from_south_side_should_move_until_it_reaches_an_obstacle() {
     let mut state = Game::new_game(ALICE, BOB, Some(INITIAL_SEED));
     let (alice_index, bob_index) = (state.player_index(&ALICE), state.player_index(&BOB));
     state.board.cells = cells;
+    state.phase = GamePhase::Play;
 
     let state = Game::drop_stone(state, ALICE, Side::South, 0).unwrap();
     assert_eq!(
@@ -493,6 +508,7 @@ fn a_stone_dropped_from_east_side_should_move_until_it_reaches_an_obstacle() {
     let mut state = Game::new_game(ALICE, BOB, Some(INITIAL_SEED));
     let (alice_index, bob_index) = (state.player_index(&ALICE), state.player_index(&BOB));
     state.board.cells = cells;
+    state.phase = GamePhase::Play;
 
     let state = Game::drop_stone(state, ALICE, Side::East, 0).unwrap();
     assert_eq!(
@@ -535,6 +551,7 @@ fn a_stone_dropped_from_west_side_should_move_until_it_reaches_an_obstacle() {
 
     let mut state = Game::new_game(ALICE, BOB, Some(INITIAL_SEED));
     state.board.cells = cells;
+    state.phase = GamePhase::Play;
 
     let state = Game::drop_stone(state, ALICE, Side::West, 0).unwrap();
     let (alice_index, bob_index) = (state.player_index(&ALICE), state.player_index(&BOB));
@@ -578,6 +595,7 @@ fn a_stone_should_explode_a_bomb_when_passing_through() {
         [o, o, o, o, o, o, o, o, o, o],
         [o, o, o, o, b, o, o, o, o, o],
     ];
+    state.phase = GamePhase::Play;
 
     let dropping_stone_result = Game::drop_stone(state.clone(), ALICE, Side::North, 5);
     assert!(dropping_stone_result.is_ok());

--- a/dot4gravity/src/tests.rs
+++ b/dot4gravity/src/tests.rs
@@ -300,7 +300,7 @@ fn a_stone_dropped_on_a_stone() {
     let o = Cell::Empty;
     let x = Cell::Stone(bob_index);
     let cells = [
-        [x, o, o, o, o, o, o, o, o, o],
+        [o, x, o, o, o, o, o, o, o, o],
         [o, o, o, o, o, o, o, o, o, o],
         [o, o, o, o, o, o, o, o, o, o],
         [o, o, o, o, o, o, o, o, o, o],
@@ -319,6 +319,72 @@ fn a_stone_dropped_on_a_stone() {
         state.board.get_cell(&Coordinates { row: 0, col: 0 }),
         Cell::Stone(alice_index)
     );
+    assert_eq!(
+        state.board.get_cell(&Coordinates { row: 0, col: 1 }),
+        Cell::Stone(bob_index)
+    );
+}
+
+#[test]
+fn a_stone_cannot_be_dropped_at_bounds() {
+    let state = Game::new_game(ALICE, BOB, Some(INITIAL_SEED));
+
+    let mut state_with_stones_at_bounds = state;
+    let o = Cell::Empty;
+    let x = Cell::Stone(state.player_index(&BOB));
+    state_with_stones_at_bounds.board.cells = [
+        [x, x, x, x, x, x, x, x, x, x],
+        [x, o, o, o, o, o, o, o, o, x],
+        [x, o, o, o, o, o, o, o, o, x],
+        [x, o, o, o, o, o, o, o, o, x],
+        [x, o, o, o, o, o, o, o, o, x],
+        [x, o, o, o, o, o, o, o, o, x],
+        [x, o, o, o, o, o, o, o, o, x],
+        [x, o, o, o, o, o, o, o, o, x],
+        [x, o, o, o, o, o, o, o, o, x],
+        [x, x, x, x, x, x, x, x, x, x],
+    ];
+
+    let mut state_with_blocks_at_bounds = state;
+    let b = Cell::Block;
+    state_with_blocks_at_bounds.board.cells = [
+        [b, b, b, b, b, b, b, b, b, b],
+        [b, o, o, o, o, o, o, o, o, b],
+        [b, o, o, o, o, o, o, o, o, b],
+        [b, o, o, o, o, o, o, o, o, b],
+        [b, o, o, o, o, o, o, o, o, b],
+        [b, o, o, o, o, o, o, o, o, b],
+        [b, o, o, o, o, o, o, o, o, b],
+        [b, o, o, o, o, o, o, o, o, b],
+        [b, o, o, o, o, o, o, o, o, b],
+        [b, b, b, b, b, b, b, b, b, x],
+    ];
+
+    for state in [state_with_stones_at_bounds, state_with_blocks_at_bounds] {
+        // left -> right check, dropping stones from top and bottom
+        for position in 0..BOARD_WIDTH {
+            assert_eq!(
+                Game::drop_stone(state, ALICE, Side::North, position),
+                Err(GameError::InvalidStonePosition)
+            );
+            assert_eq!(
+                Game::drop_stone(state, ALICE, Side::South, position),
+                Err(GameError::InvalidStonePosition)
+            );
+        }
+
+        // top -> bottom check, dropping stones from left and right
+        for position in 0..BOARD_HEIGHT {
+            assert_eq!(
+                Game::drop_stone(state, ALICE, Side::West, position),
+                Err(GameError::InvalidStonePosition)
+            );
+            assert_eq!(
+                Game::drop_stone(state, ALICE, Side::East, position),
+                Err(GameError::InvalidStonePosition)
+            );
+        }
+    }
 }
 
 #[test]

--- a/dot4gravity/src/tests.rs
+++ b/dot4gravity/src/tests.rs
@@ -131,7 +131,7 @@ fn a_player_cannot_drop_bomb_in_play_phase() {
     let mut game_state = Game::new_game(ALICE, BOB, Some(INITIAL_SEED));
     game_state.phase = GamePhase::Play;
     let result = Game::drop_bomb(game_state, TEST_COORDINATES, ALICE);
-    assert_eq!(result, Err(GameError::DroppedBombDuringPlayPhase));
+    assert_eq!(result, Err(GameError::DroppedBombOutsideBombPhase));
 }
 
 #[test]
@@ -273,7 +273,7 @@ fn a_player_cannot_drop_a_stone_in_bomb_phase() {
     assert_eq!(state.phase, GamePhase::Bomb);
     assert_eq!(
         Game::drop_stone(state, BOB, Side::North, 0),
-        Err(GameError::DroppedStoneDuringBombPhase)
+        Err(GameError::DroppedStoneOutsidePlayPhase)
     );
 }
 

--- a/dot4gravity/src/traits.rs
+++ b/dot4gravity/src/traits.rs
@@ -1,0 +1,28 @@
+// Ajuna Node
+// Copyright (C) 2022 BlogaTech AG
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::{Coordinates, BOARD_HEIGHT, BOARD_WIDTH};
+
+pub(crate) trait Bound {
+    /// Tells if something is inside the board.
+    fn is_inside_board(&self) -> bool;
+}
+
+impl Bound for Coordinates {
+    fn is_inside_board(&self) -> bool {
+        self.row < BOARD_WIDTH && self.col < BOARD_HEIGHT
+    }
+}

--- a/dot4gravity/src/traits.rs
+++ b/dot4gravity/src/traits.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{Coordinates, BOARD_HEIGHT, BOARD_WIDTH};
+use crate::{Coordinates, Position, BOARD_HEIGHT, BOARD_WIDTH};
 
 pub(crate) trait Bound {
     /// Tells if something is inside the board.
@@ -24,5 +24,11 @@ pub(crate) trait Bound {
 impl Bound for Coordinates {
     fn is_inside_board(&self) -> bool {
         self.row < BOARD_WIDTH && self.col < BOARD_HEIGHT
+    }
+}
+
+impl Bound for Position {
+    fn is_inside_board(&self) -> bool {
+        self < &BOARD_WIDTH && self < &BOARD_HEIGHT
     }
 }


### PR DESCRIPTION
Changes:
- rename `InvalidStonePosition` -> `InvalidStonePosition` (for consistency with `InvalidBombPosition`)
- move and implement `is_inside_board` check inside `Bound` trait
- add `Cell.is_stone()`, `Side.bound_coordinates()`, `Board.is_stone_droppable()` to be used inside `can_drop_stone` check
- update `can_drop_stone` to check for `GamePhase::Player` (else return `DroppedStoneDuringBombPhase` error)
- add tests accordingly

Closes #6.