### PR TITLE
Add GameAlreadyFinished error

### DIFF
--- a/dot4gravity/src/lib.rs
+++ b/dot4gravity/src/lib.rs
@@ -227,6 +227,8 @@ pub enum GameError {
     NotPlayerTurn,
     /// The cell has no previous position. It is an edge cell.
     NoPreviousPosition,
+    /// Tried playing when game has finished.
+    GameAlreadyFinished,
 }
 
 #[derive(Encode, Decode, TypeInfo, MaxEncodedLen, Copy, Clone, Debug, Eq, PartialEq)]
@@ -331,6 +333,9 @@ impl<Player: PartialEq + Clone> Game<Player> {
         if game_state.phase != GamePhase::Bomb {
             return Err(GameError::DroppedBombOutsideBombPhase);
         }
+        if game_state.winner.is_some() {
+            return Err(GameError::GameAlreadyFinished);
+        }
         if game_state.is_all_player_bomb_dropped(player) {
             return Err(GameError::NoMoreBombsAvailable);
         }
@@ -348,6 +353,9 @@ impl<Player: PartialEq + Clone> Game<Player> {
     ) -> Result<(), GameError> {
         if game_state.phase != GamePhase::Play {
             return Err(GameError::DroppedStoneOutsidePlayPhase);
+        }
+        if game_state.winner.is_some() {
+            return Err(GameError::GameAlreadyFinished);
         }
         if !game_state.is_player_turn(player) {
             return Err(GameError::NotPlayerTurn);

--- a/dot4gravity/src/tests.rs
+++ b/dot4gravity/src/tests.rs
@@ -156,6 +156,16 @@ fn a_player_cannot_drop_bomb_if_already_dropped_all() {
 }
 
 #[test]
+fn a_player_cannot_drop_bomb_if_game_already_finished() {
+    let mut game_state = Game::new_game(ALICE, BOB, Some(INITIAL_SEED));
+    game_state.winner = Some(ALICE);
+    assert_eq!(
+        Game::drop_bomb(game_state, TEST_COORDINATES, BOB),
+        Err(GameError::GameAlreadyFinished),
+    )
+}
+
+#[test]
 fn dropping_bomb_should_not_update_last_move() {
     let mut game_state = Game::new_game(ALICE, BOB, Some(INITIAL_SEED));
     game_state.board.update_cell(TEST_COORDINATES, Cell::Empty);
@@ -295,6 +305,17 @@ fn a_player_cannot_drop_a_stone_out_of_turn() {
     state.phase = GamePhase::Play;
     let drop_stone_result = Game::drop_stone(state, BOB, Side::North, 0);
     assert_eq!(drop_stone_result, Err(GameError::NotPlayerTurn));
+}
+
+#[test]
+fn a_player_cannot_drop_stone_if_game_already_finished() {
+    let mut game_state = Game::new_game(ALICE, BOB, Some(INITIAL_SEED));
+    game_state.phase = GamePhase::Play;
+    game_state.winner = Some(BOB);
+    assert_eq!(
+        Game::drop_stone(game_state, ALICE, Side::East, 1),
+        Err(GameError::GameAlreadyFinished),
+    )
 }
 
 #[test]


### PR DESCRIPTION
This is a companion PR for https://github.com/ajuna-network/Ajuna/pull/40 to allow `T::Game::play_turn` to early exit if there's a winner.

Changes:
- add and return `GameAlreadyFinished` error when trying to play a game that's already finished
  - (at the moment, a game is considered finished if there is some winner)