### PR TITLE
Light refactoring for cells affected by an explosion

### DIFF
--- a/dot4gravity/src/lib.rs
+++ b/dot4gravity/src/lib.rs
@@ -155,6 +155,19 @@ impl Board {
         position.is_inside_board() && self.get_cell(position).is_stone_droppable()
     }
 
+    #[allow(dead_code)]
+    /// If the given cell position is a stone, return owner player index
+    fn player_index_stone(&self, position: &Coordinates) -> Option<PlayerIndex> {
+        if !position.is_inside_board() {
+            return None;
+        }
+        if let Cell::Stone(p) = self.get_cell(position) {
+            Some(p)
+        } else {
+            None
+        }
+    }
+
     fn get_cell(&self, position: &Coordinates) -> Cell {
         let cell = &self.cells[position.row as usize][position.col as usize];
         *cell
@@ -168,7 +181,8 @@ impl Board {
         );
     }
 
-    fn explode_bomb(&mut self, bomb_position: Coordinates) {
+    /// Return coordinates affected by a potential explosion
+    fn explodable_coordinate(&self, position: &Coordinates) -> Vec<Coordinates> {
         let offsets: [(i8, i8); 9] = [
             (0, 0),
             (-1, -1),
@@ -185,15 +199,21 @@ impl Board {
             .iter()
             .map(|(row_offset, col_offset)| {
                 Coordinates::new(
-                    (row_offset + bomb_position.row as i8) as u8,
-                    (col_offset + bomb_position.col as i8) as u8,
+                    (row_offset + position.row as i8) as u8,
+                    (col_offset + position.col as i8) as u8,
                 )
             })
+            .collect()
+    }
+
+    fn explode_bomb(&mut self, bomb_position: Coordinates) {
+        self.explodable_coordinate(&bomb_position)
+            .into_iter()
             .for_each(|position| {
                 if self.is_explodable(&position) {
                     self.update_cell(position, Cell::Empty)
                 }
-            });
+            })
     }
 }
 

--- a/dot4gravity/src/lib.rs
+++ b/dot4gravity/src/lib.rs
@@ -36,9 +36,14 @@ const NUM_OF_PLAYERS: usize = 2;
 const NUM_OF_BOMBS_PER_PLAYER: u8 = 3;
 const NUM_OF_BLOCKS: u8 = 10;
 
+// Score
+const NB_POINT_STONE: u8 = 1;
+const NB_POINT_ENEMY_STONE_DESTROYED: u8 = 1;
+
 type PlayerIndex = u8;
 type Position = u8;
 type Seed = u32;
+type Score = u8;
 
 /// Represents a cell of the board.
 #[allow(private_in_public)]
@@ -155,7 +160,6 @@ impl Board {
         position.is_inside_board() && self.get_cell(position).is_stone_droppable()
     }
 
-    #[allow(dead_code)]
     /// If the given cell position is a stone, return owner player index
     fn player_index_stone(&self, position: &Coordinates) -> Option<PlayerIndex> {
         if !position.is_inside_board() {
@@ -284,6 +288,8 @@ pub struct GameState<Player> {
     pub players: [Player; NUM_OF_PLAYERS],
     /// Number of bombs available for each player.
     pub bombs: [(Player, u8); NUM_OF_PLAYERS],
+    /// Current score for each player.
+    pub scores: [(Player, Score); NUM_OF_PLAYERS],
     /// Represents the last move.
     pub last_move: Option<LastMove<Player>>,
 }
@@ -319,6 +325,42 @@ impl<Player: PartialEq + Clone> GameState<Player> {
             }
         }
     }
+
+    /// Return current player score
+    pub fn get_player_score(&self, player: &Player) -> Score {
+        self.scores
+            .iter()
+            .find(|(p, _)| *p == *player)
+            .map(|(_, current_score)| *current_score)
+            .unwrap()
+    }
+
+    /// Increase player score
+    pub fn increase_player_score(&mut self, player: &Player, add_score: u8) {
+        for (p, current_score) in self.scores.iter_mut() {
+            if *p == *player {
+                *current_score += add_score;
+            }
+        }
+    }
+
+    /// Return nb opponent player stones in the explodable area
+    fn adjacent_opponent_stone(&self, position: Coordinates, player: &Player) -> u8 {
+        let mut nb_adjacent_opponent_stone = 0;
+
+        self.board
+            .explodable_coordinate(&position)
+            .into_iter()
+            .for_each(|position| match self.board.player_index_stone(&position) {
+                Some(player_index) if player_index != self.player_index(player) => {
+                    nb_adjacent_opponent_stone += 1;
+                }
+                _ => {}
+            });
+
+        nb_adjacent_opponent_stone
+    }
+
     pub fn is_player_turn(&self, player: &Player) -> bool {
         self.next_player == *player
     }
@@ -416,6 +458,10 @@ impl<Player: PartialEq + Clone> Game<Player> {
             winner: Default::default(),
             next_player: player1.clone(),
             players: [player1.clone(), player2.clone()],
+            scores: [
+                (player1.clone(), Score::default()),
+                (player2.clone(), Score::default()),
+            ],
             bombs: [
                 (player1, NUM_OF_BOMBS_PER_PLAYER),
                 (player2, NUM_OF_BOMBS_PER_PLAYER),
@@ -489,6 +535,11 @@ impl<Player: PartialEq + Clone> Game<Player> {
                     match game_state.board.get_cell(&position) {
                         // A cell bomb must explode.
                         Cell::Bomb([_, _]) => {
+                            game_state.increase_player_score(
+                                &player,
+                                NB_POINT_ENEMY_STONE_DESTROYED
+                                    * game_state.adjacent_opponent_stone(position, &player),
+                            );
                             game_state.board.explode_bomb(position);
                             stop = true;
                         }
@@ -537,6 +588,11 @@ impl<Player: PartialEq + Clone> Game<Player> {
                     match game_state.board.get_cell(&position) {
                         // A cell bomb must explode.
                         Cell::Bomb([_, _]) => {
+                            game_state.increase_player_score(
+                                &player,
+                                NB_POINT_ENEMY_STONE_DESTROYED
+                                    * game_state.adjacent_opponent_stone(position, &player),
+                            );
                             game_state.board.explode_bomb(position);
                             break;
                         }
@@ -588,6 +644,11 @@ impl<Player: PartialEq + Clone> Game<Player> {
                     match game_state.board.get_cell(&position) {
                         // A cell bomb must explode.
                         Cell::Bomb([_, _]) => {
+                            game_state.increase_player_score(
+                                &player,
+                                NB_POINT_ENEMY_STONE_DESTROYED
+                                    * game_state.adjacent_opponent_stone(position, &player),
+                            );
                             game_state.board.explode_bomb(position);
                             break;
                         }
@@ -640,6 +701,11 @@ impl<Player: PartialEq + Clone> Game<Player> {
                     match game_state.board.get_cell(&position) {
                         // A cell bomb must explode.
                         Cell::Bomb([_, _]) => {
+                            game_state.increase_player_score(
+                                &player,
+                                NB_POINT_ENEMY_STONE_DESTROYED
+                                    * game_state.adjacent_opponent_stone(position, &player),
+                            );
                             game_state.board.explode_bomb(position);
                             stop = true;
                         }
@@ -682,6 +748,7 @@ impl<Player: PartialEq + Clone> Game<Player> {
             }
         }
 
+        game_state.increase_player_score(&player, NB_POINT_STONE);
         game_state.last_move = Some(LastMove::new(player, side, position));
         game_state.next_player = game_state.next_player().clone();
         game_state = Game::check_winner_player(game_state);


### PR DESCRIPTION
I refactored `explode_bomb` with a generic function which give me cells affected by an explosion (i'm going to need it to get the opponent player stone affected by an explosion).
Added an other function to get  the the player index of a stone cell (going to remove my allow(dead_code) on the next PR)